### PR TITLE
Removing WinRM specific code from spec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 #  Copyright 2014 Puppet Community
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,6 @@ group :development do
 end
 
 group :system_tests do
-  gem "beaker"
+  gem "beaker", :git => 'https://github.com/petems/beaker-windows.git'
   gem "beaker-rspec"
 end

--- a/spec/acceptance/windowsfeature_spec.rb
+++ b/spec/acceptance/windowsfeature_spec.rb
@@ -3,17 +3,13 @@ require 'spec_helper_acceptance'
 describe 'windowsfeature' do
   context 'windows feature should be installed' do
     it 'should install .net 3.5 feature' do
-        
+
       pp = <<-PP
         windowsfeature { 'as-net-framework': }
       PP
-      
+
       apply_manifest(pp, :catch_failures => true)
       expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
-    end
-    
-    describe windows_feature('as-net-framework') do
-      it { should be_installed.by('powershell') }
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,37 +2,35 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'winrm'
 
+GEOTRUST_GLOBAL_CA = <<-EOM
+-----BEGIN CERTIFICATE-----
+MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
+YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
+EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
+R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
+9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
+fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
+iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
+1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
+  bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
+MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
+ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
+uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
+Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
+tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
+PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
+hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
+5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
+-----END CERTIFICATE-----
+EOM
+
 hosts.each do |host|
-
-  if host['platform'] =~ /windows/
-    include Serverspec::Helper::Windows
-    include Serverspec::Helper::WinRM
-
-    # This hack to install .net 3.5 exists because .net 3.5 has to be installed on 2012 and 2012 R2
-    # in order for puppet to install
-    #
-    # @see PUP-1951
-    # @see PUP-3965
-    if host.to_s =~ /2012/
-      DOTNET_HACK = <<-EOF.gsub!(/\n+/, '').gsub!(/^\s+/, '')
-      $webclient = New-Object System.Net.WebClient ;
-      $webclient.DownloadFile('https://googledrive.com/host/0B4_Bou5W3VsSfjRmeTBaak1Da2ZtVE95M25teWlfa0Y1NEVEYlBHNGV3S3liQTlWNTBGR0E/sxs.zip','C:\\Windows\\Temp\\sxs.zip') ;
-      Add-Type -Assembly 'System.IO.Compression.FileSystem' ;
-      [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\\Windows\\Temp\\sxs.zip', 'C:\\Windows\\Temp\\sxs') ;
-      Install-WindowsFeature Net-Framework-Core -source C:\\Windows\\Temp\\sxs ;
-      shutdown /r /t 0
-      EOF
-
-      on host, powershell(DOTNET_HACK)
-      sleep(30)
-      host.close
-      sleep(10)
-      host.connection
-    end
-  end
-
-  version = ENV['PUPPET_GEM_VERSION'] || '3.7.5'
+  version = ENV['PUPPET_GEM_VERSION'] || '3.8.3'
   install_puppet(:version => version)
+  install_cert_on_windows(host, 'geotrustglobal', GEOTRUST_GLOBAL_CA)
+  on host, puppet('module','install', "puppetlabs-stdlib")
+  on host, puppet('module','install', "puppetlabs-powershell")
 end
 
 RSpec.configure do |c|
@@ -41,49 +39,9 @@ RSpec.configure do |c|
   c.formatter = :documentation
 
   c.before :suite do
-
-    GEOTRUST_GLOBAL_CA = <<-EOM
-    -----BEGIN CERTIFICATE-----
-    MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
-    MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
-    YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
-    EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
-    R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
-    9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
-    fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
-    iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
-    1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
-      bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
-    MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
-    ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
-    uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
-    Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
-    tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
-    PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
-    hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
-    5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
-    -----END CERTIFICATE-----
-    EOM
-
-    hosts.each do |host|
-      c.host = host
-
-      if host['platform'] =~ /windows/
-        endpoint = "http://127.0.0.1:5985/wsman"
-        c.winrm = WinRM::WinRMWebService.new(endpoint, :ssl, :user => 'vagrant', :pass => 'vagrant', :basic_auth_only => true)
-        c.winrm.set_timeout 300
-      end
-
-      path = (File.expand_path(File.dirname(__FILE__)+'/../')).split('/')
-      name = path[path.length-1].split('-')[1]
-
-      copy_module_to(host, :source => proj_root, :module_name => name)
-
-      install_cert_on_windows(host, 'geotrustglobal', GEOTRUST_GLOBAL_CA) 
-
-      on host, puppet('module','install', "puppetlabs-stdlib"), { :acceptable_exit_codes => [0] }
-      on host, puppet('module','install', "puppetlabs-powershell"), { :acceptable_exit_codes => [0] }
-
-    end
+    path = (File.expand_path(File.dirname(__FILE__)+'/../')).split('/')
+    name = path[path.length-1].split('-')[1]
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => name)
   end
 end


### PR DESCRIPTION
* WinRM beaker features currently not working (See BKR-328 for more details)
* Using fork of Beaker that has specific windows provider tests